### PR TITLE
EDITORS-247 API adjustments

### DIFF
--- a/bundles/org.palladiosimulator.architecturaltemplates.api/src/org/palladiosimulator/architecturaltemplates/api/ArchitecturalTemplateAPI.java
+++ b/bundles/org.palladiosimulator.architecturaltemplates.api/src/org/palladiosimulator/architecturaltemplates/api/ArchitecturalTemplateAPI.java
@@ -149,6 +149,23 @@ public final class ArchitecturalTemplateAPI {
     }
 
     /**
+     * Tests whether a {@link StereotypeApplication} belongs to an architectural template.
+     */
+	public static boolean isArchitecturalTemplateStereotypeApplication(
+			final StereotypeApplication stereotypeApplication) {
+		return Optional.ofNullable(stereotypeApplication).map(StereotypeApplication::getStereotype)
+				.map(ArchitecturalTemplateAPI::isArchitecturalTemplateStereotype).orElse(false);
+	}
+
+    /**
+     * Tests whether a {@link Stereotype} belongs to an architectural template.
+     */
+	public static boolean isArchitecturalTemplateStereotype(final Stereotype stereotype) {
+		return Optional.ofNullable(stereotype).map(Stereotype::getProfile)
+				.map(ArchitecturalTemplateAPI::isArchitecturalTemplate).orElse(false);
+	}
+
+    /**
      * Tests whether a {@link Profile} is an Architectural-Template. {@see #isArchitecturalTemplate}
      */
     public static boolean isArchitecturalTemplate(final Profile profile) {
@@ -498,11 +515,11 @@ public final class ArchitecturalTemplateAPI {
         return roleStereotypeApplications;
     }
 
-    public static Collection<StereotypeApplication> getStereotypeApplicationsWithoutRoles(final EObject eObject) {
+    public static Collection<StereotypeApplication> getATStereotypeApplicationsWithoutRoles(final EObject eObject) {
         final Collection<StereotypeApplication> roleStereotypeApplications = new ArrayList<>();
 
         for (final StereotypeApplication stereotypeApplication : StereotypeAPI.getStereotypeApplications(eObject)) {
-            if (!isRole(stereotypeApplication.getStereotype())) {
+            if (isArchitecturalTemplateStereotypeApplication(stereotypeApplication) && !isRole(stereotypeApplication.getStereotype())) {
                 roleStereotypeApplications.add(stereotypeApplication);
             }
         }
@@ -513,11 +530,12 @@ public final class ArchitecturalTemplateAPI {
     /**
      * TODO documentation
      */
-    public static final Collection<ProfileImport> getProfileImports(final EObject eObject) {
-        if (ProfileAPI.hasProfileApplication(eObject.eResource())) {
-            return Collections.unmodifiableCollection(
-                    ProfileAPI.getProfileApplication(eObject.eResource()).getImportedProfiles());
-        }
+    public static final Collection<ProfileImport> getATProfileImports(final EObject eObject) {
+		if (ProfileAPI.hasProfileApplication(eObject.eResource())) {
+			return Collections.unmodifiableCollection(
+					ProfileAPI.getProfileApplication(eObject.eResource()).getImportedProfiles().stream()
+							.filter(pi -> isArchitecturalTemplate(pi.getProfile())).collect(Collectors.toList()));
+		}
         return Collections.emptyList();
     }
 


### PR DESCRIPTION
This PR adjusts the AT API solely used by the Sirius editors in order to fix the behavior. The methods of the API often assume that the only profiles and stereotypes applied are related to ATs, which does not hold in reality. This PR fixes the behavior.

After merging this PR, PalladioSimulator/Palladio-Editors-Sirius#11 should be merged in order to prevent breaking the editors build.