### PR TITLE
WFE-83 Remove unused trace model usage

### DIFF
--- a/bundles/org.palladiosimulator.architecturaltemplates.jobs/src/org/palladiosimulator/architecturaltemplates/jobs/RunATCompletionJob.java
+++ b/bundles/org.palladiosimulator.architecturaltemplates.jobs/src/org/palladiosimulator/architecturaltemplates/jobs/RunATCompletionJob.java
@@ -83,9 +83,6 @@ public class RunATCompletionJob extends SequentialBlackboardInteractingJob<MDSDB
     /** Options for QVT-O job. */
     private static final HashMap<String, Object> QVTO_OPTIONS = new HashMap<String, Object>();
 
-    /** Folder with traces as created by the QVT-O engine. */
-    private static final String TRACESFOLDER = "traces";
-
     public static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
         Map<Object,Boolean> seen = new ConcurrentHashMap<>();
         return t -> seen.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
@@ -129,7 +126,6 @@ public class RunATCompletionJob extends SequentialBlackboardInteractingJob<MDSDB
     private QVTOTransformationJobConfiguration createQvtoConfiguration(final QVTOCompletion completion) {
         final QVTOTransformationJobConfiguration qvtoConfig = new QVTOTransformationJobConfiguration();
         qvtoConfig.setInoutModels(getModelLocations(completion));
-        qvtoConfig.setTraceFileURI(URI.createURI(TRACESFOLDER));
         qvtoConfig.setScriptFileURI(getRootURI(completion).appendSegment(COMPLETIONS_FOLDER)
                 .appendSegment(completion.getCompletionFileURI()));
         qvtoConfig.setOptions(QVTO_OPTIONS);


### PR DESCRIPTION
Trace models did not work until WFE-83. Therefore, the trace model never
existed and is not needed by this job or its users. Additionally, the
configuration parameter clearly states that the URI is intended to be a
file URI instead of a folder URI, which means that the configuration has
been used in a wrong way.

Has to be merged before PalladioSimulator/Palladio-Supporting-WorkflowEngine#6.